### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,5 +23,5 @@ VOLUME ["/data/graph/"]
 VOLUME ["/data/out/"]
 
 ENTRYPOINT ["./dw", "gibbs", "-w /data/graph/graph.weights", "-v /data/graph/graph.variables", "-f /data/graph/graph.factors", "-e /data/graph/graph.edges", "-m /data/graph/graph.meta", "-o /data/out"]
-CMD ["-l 1000", "-d 0.99", "-s 1", "-i 500", "--alpha 0.01"]
+CMD ["-i 500",  "-s 1", "-l 1000"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,11 @@ RUN ["/bin/bash", "-c", "make dep"]
 RUN ["/bin/bash", "-c", "make"]
 RUN ["/bin/bash", "-c", "make test"]
 
-RUN mkdir -p /data/sampler
-VOLUME ["/data/sampler/"]
+RUN mkdir -p /data/graph
+RUN mkdir -p /data/out
+VOLUME ["/data/graph/"]
+VOLUME ["/data/out/"]
+
+ENTRYPOINT ["./dw", "gibbs", "-w /data/graph/graph.weights", "-v /data/graph/graph.variables", "-f /data/graph/graph.factors", "-e /data/graph/graph.edges", "-m /data/graph/graph.meta", "-o /data/out"]
+CMD ["-l 1000", "-d 0.99", "-s 1", "-i 500", "--alpha 0.01"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu
 MAINTAINER skruzel@astrocyte.io
 RUN apt-get update
 RUN apt-get install -y gnuplot python libpython2.7-dev default-jre default-jdk emacs postgresql postgresql-contrib git build-essential libnuma-dev bc unzip locales
+RUN apt-get install -y cmake
 RUN locale-gen en_US en_US.UTF-8 && dpkg-reconfigure locales
 
 ENV USER=root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu
+MAINTAINER skruzel@astrocyte.io
+RUN apt-get update
+RUN apt-get install -y gnuplot python libpython2.7-dev default-jre default-jdk emacs postgresql postgresql-contrib git build-essential libnuma-dev bc unzip locales
+RUN locale-gen en_US en_US.UTF-8 && dpkg-reconfigure locales
+
+ENV USER=root
+WORKDIR /root
+#RUN git clone https://github.com/closedLoop/sampler.git
+ADD . sampler
+WORKDIR /root/sampler
+# ENV DEBIAN_FRONTEND=noninteractive
+ENV SHELL=/bin/bash
+
+RUN ["/bin/bash", "-c", "make dep"]
+RUN ["/bin/bash", "-c", "make"]
+RUN ["/bin/bash", "-c", "make test"]
+
+RUN mkdir -p /data/sampler
+VOLUME ["/data/sampler/"]

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ TEST_PROGRAM = $(PROGRAM)_test
 # test files need gtest
 $(TEST_OBJECTS): CXXFLAGS += -I./lib/gtest-1.7.0/include/
 $(TEST_PROGRAM): LDFLAGS += -L./lib/gtest/
-$(TEST_PROGRAM): LDLIBS += -lgtest
+$(TEST_PROGRAM): LDLIBS += -lgtest -lpthread
 
 # how to link our sampler
 $(PROGRAM): $(OBJECTS)


### PR DESCRIPTION
Created basic implementation of stand-along sampler using docker
## Basic Usage

``` bash
docker run -it -v $GRAPH_FOLDER:/data/graph -v $OUTPUT_FOLDER:/data/out closedloop/sampler
```

where
- **$GRAPH_FOLDER** is the location of the `graph.weights, graph.variables, graph.factors, graph.edges graph.meta` files
- **$OUTPUT_FOLDER** is the folder location for the generated `inference_result.out.text` and `inference_result.out.weights.text` files

The basic usage example above calls the following function:

``` bash
./dw gibbs -w /data/graph/graph.weights -v /data/graph/graph.variables -f /data/graph/graph.factors -e /data/graph/graph.edges -m /data/graph/graph.meta -o /data/out -i 500 -s 1 -l 1000
```
## Alternative Usages:
1. Pass in custom non-file related parameters

``` bash
docker run -it -v $GRAPH_FOLDER:/data/graph -v $OUTPUT_FOLDER:/data/out closedloop/sampler -i 1000 -s 1 -l 1000 --alpha 0.01
```
## Missing features
- Currently the only entrypoint into docker is to call `./dw gibbs`  there may be desire to add other entrypoints
